### PR TITLE
Improve codebase and runtime

### DIFF
--- a/includes/config.hpp
+++ b/includes/config.hpp
@@ -70,12 +70,12 @@ public:
 
   static Config *the();
 
-  void init(const std::string& dir);
+  void init(const std::string_view dir);
 
-  void set_property(const std::string& key, const std::string& value);
+  void set_property(const std::string_view key, const std::string_view value);
 
-  void generate_config_file(const std::string& path);
+  void generate_config_file(const std::string_view path);
 
-  std::string get_property(const std::string& key);
+  std::string get_property(const std::string_view key);
 
 };

--- a/includes/image.hpp
+++ b/includes/image.hpp
@@ -28,10 +28,10 @@ namespace sfImage {
 
   bool is_supported_image(const std::filesystem::path& image_path);
 
-  std::pair<int, int> get_img_resolution(const std::filesystem::path& image_path);
+  std::array<int, 2> get_img_resolution(const std::filesystem::path& image_path);
 
-  size_t img_height_when_width(const std::filesystem::path& image_path, size_t width);
+  size_t img_height_when_width(const std::filesystem::path& image_path, const size_t width);
 
-  void preview_image(const std::filesystem::path& image_path, size_t width);
+  void preview_image(const std::filesystem::path& image_path, const size_t width);
 
 }

--- a/includes/info.hpp
+++ b/includes/info.hpp
@@ -47,7 +47,7 @@ private:
     {"USER", user}
   };
 
-  const std::string default_config = R"(# Comments start with '#'
+  static constexpr std::string_view default_config = R"(# Comments start with '#'
 
 # Available variables:
 #   'CPU', 'DE', 'DISTRO', 'GPU', 'HOST', 'KERNEL', 'MODEL',
@@ -75,11 +75,11 @@ private:
 public:
   static Info *the();
 
-  void init(const std::string& dir);
+  void init(const std::string_view dir);
 
   const std::vector<std::string>& get_info();
 
-  void generate_config_file(const std::string& path);
+  void generate_config_file(const std::string_view path);
 
   size_t get_info_size();
 };

--- a/includes/sysfex.hpp
+++ b/includes/sysfex.hpp
@@ -33,7 +33,7 @@ namespace Sysfex {
 
   void about();
 
-  void import_config();
+  void import_config(const bool init_config, const bool init_info);
 
   void help();
 

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -21,8 +21,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <iostream>
 #include <string>
+#include <vector>
 #include <memory>
-#include <cctype> // for std::isspace
 #include <unordered_map>
 #include <unicode/uchriter.h>
 #include <unicode/uchar.h>
@@ -83,12 +83,14 @@ static std::unordered_map<std::string, std::string> COLOR_VALUES = {
 
 namespace sfUtils {
 
-  size_t get_string_display_width(const std::string& line);
+  size_t get_string_display_width(const std::string_view line);
 
-  std::string get_output_of(const char *command);
+  std::string get_output_of(const std::string_view command);
 
-  std::string parse_string(const std::string &source, bool peel);
+  std::string parse_string(const std::string_view source, bool peel);
 
-  std::string trim_string_spaces(const std::string& source);
-  
+  std::string trim_string_spaces(std::string input);
+
+  bool        taur_exec(const std::vector<std::string> cmd_str);
+
 }

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -91,6 +91,6 @@ namespace sfUtils {
 
   std::string trim_string_spaces(std::string input);
 
-  bool        taur_exec(const std::vector<std::string> cmd_str);
+  bool        taur_exec(const std::vector<std::string_view> cmd_str);
 
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,27 +25,27 @@ Config *Config::the() {
   return &sysfex_config;
 }
 
-void Config::set_property(const std::string& key, const std::string& value) {
-  if (config.find(key) != config.end()) {
-    config[key] = value;
+void Config::set_property(const std::string_view key, const std::string_view value) {
+  if (config.find(key.data()) != config.end()) {
+    config[key.data()] = value;
   }
 }
 
-std::string Config::get_property(const std::string& key) {
-  if (config.find(key) != config.end()) {
-    return config[key];
+std::string Config::get_property(const std::string_view key) {
+  if (config.find(key.data()) != config.end()) {
+    return config[key.data()];
   }
   return "";
 }
 
-void Config::generate_config_file(const std::string& path) {
-  std::ofstream generated_file(path);
+void Config::generate_config_file(const std::string_view path) {
+  std::ofstream generated_file(path.data());
   generated_file << default_config;
   generated_file.close();
 }
 
-void Config::init(const std::string& dir) {
-  std::ifstream config_file(dir);
+void Config::init(const std::string_view dir) {
+  std::ifstream config_file(dir.data());
   if (!config_file.is_open()) {
     return;
   }
@@ -63,9 +63,9 @@ void Config::init(const std::string& dir) {
     }
 
     /* Find delimiter '=' and split key and value */
-    size_t delimiter = current_line.find('=');
-    std::string key = current_line.substr(0, delimiter);
-    std::string value = current_line.substr(delimiter + 1);
+    const size_t delimiter = current_line.find('=');
+    const std::string& key = current_line.substr(0, delimiter);
+    const std::string& value = current_line.substr(delimiter + 1);
     set_property(key, value);
   }
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -63,7 +63,7 @@ size_t sfImage::img_height_when_width(const std::filesystem::path& image_path, c
 
 void sfImage::preview_image(const std::filesystem::path& image_path, const size_t width) {
   /* Check if `viu` is installed in the system */
-  if (!sfUtils::taur_exec({ "sh", "-c", "command", "-v", "viu", ">", "/dev/null", "2>&1" })) {
+  if (!sfUtils::taur_exec({ "sh", "-c", "command -v viu > /dev/null 2>&1" })) {
     /* Nothing */
     return;
   }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -68,5 +68,5 @@ void sfImage::preview_image(const std::filesystem::path& image_path, const size_
     return;
   }
 
-  sfUtils::taur_exec({"viu", image_path, "-w", std::to_string(width)});
+  sfUtils::taur_exec({"viu", image_path.string(), "-w", std::to_string(width)});
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -57,7 +57,7 @@ void Info::init(const std::string_view dir) {
     }
 
     const size_t left_quote = current_line.find('"');
-    const size_t right_quote = current_line.find_last_of('"');
+    const size_t right_quote = current_line.rfind('"');
     if (left_quote == std::string::npos or left_quote == right_quote) {
       continue;
     }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -33,18 +33,18 @@ size_t Info::get_info_size() {
   return infos.size();
 }
 
-void Info::generate_config_file(const std::string& path) {
-  std::ofstream generated_file(path);
+void Info::generate_config_file(const std::string_view path) {
+  std::ofstream generated_file(path.data());
   generated_file << default_config;
   generated_file.close();
 }
 
-void Info::init(const std::string& dir) {
+void Info::init(const std::string_view dir) {
   if (!std::filesystem::exists(dir)) {
     return;
   }
 
-  std::ifstream infile(dir);
+  std::ifstream infile(dir.data());
   if (!infile.is_open()) {
     return;
   }
@@ -56,19 +56,19 @@ void Info::init(const std::string& dir) {
       continue;
     }
 
-    size_t left_quote = current_line.find('"');
-    size_t right_quote = current_line.find_last_of('"');
+    const size_t left_quote = current_line.find('"');
+    const size_t right_quote = current_line.find_last_of('"');
     if (left_quote == std::string::npos or left_quote == right_quote) {
       continue;
     }
     current_line = current_line.substr(left_quote + 1, right_quote - left_quote - 1);
 
     for (auto &pair : printables) {
-      std::string placeholder = "{" + pair.first + "}";
+      const std::string& placeholder = "{" + pair.first + "}";
       size_t pos = current_line.find(placeholder);
       while (pos != std::string::npos) {
-        std::string info = pair.second();
-        size_t info_length = info.length();
+        const std::string& info = pair.second();
+        const size_t info_length = info.length();
         current_line.replace(pos, placeholder.length(), info);
         pos = current_line.find(placeholder, pos + info_length);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,42 +18,58 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "sysfex.hpp"
+#include <getopt.h>
 
-int main(int argc, const char *argv[]) {
-  Sysfex::import_config();
+int main(int argc, char *argv[]) {
+  bool init_config = true;
+  bool init_info = true;
 
-  for (int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "--about") == 0) {
-      Sysfex::about();
-      return 0;
-    }
-    if (strcmp(argv[i], "--help") == 0) {
-      Sysfex::help();
-      return 0;
-    }
+  int opt = 0;
+  int option_index = 0;
+  const char *optstring = "-bha:C:i:";
+  static const struct option opts[] = {
+    {"about",  no_argument,       0, 'b'},
+    {"help",   no_argument,       0, 'h'},
+    {"ascii",  required_argument, 0, 'a'},
+    {"config", required_argument, 0, 'C'},
+    {"info",   required_argument, 0, 'i'},
+    {0,0,0,0}
+  };
 
-    /* Flags requiring values should not be the last argument */
-    if (i != argc - 1) {
-      if (strcmp(argv[i], "--ascii") == 0) {
-        Config::the()->set_property("ascii", argv[++i]);
-      } else if (strcmp(argv[i], "--config") == 0) {
-        Config::the()->init(argv[++i]);
-      } else if (strcmp(argv[i], "--info") == 0) {
-        Info::the()->init(argv[++i]);
-      } else {
-        std::cerr << sfUtils::parse_string(
-          std::string("\\f_redInvalid flag: `") + argv[i] + "`\\reset\n",
-          false
-        );
+  while ((opt = getopt_long(argc, argv, optstring, opts, &option_index)) != -1) {
+    switch (opt) {
+      case 0:
+        break;
+      case '?':
+        std::cout << sfUtils::parse_string("\\f_redInvalid format\n\\reset", false);
+        Sysfex::help();
         return 1;
-      }
-    } else {
-      std::cout << sfUtils::parse_string("\\f_redInvalid format\n\\reset", false);
-      Sysfex::help();
-      return 1;
+
+      case 'b':
+        Sysfex::about();
+        return 0;
+
+      case 'h':
+        Sysfex::help();
+        return 0;
+
+      case 'a':
+        Config::the()->set_property("ascii", optarg);
+        break;
+
+      case 'i':
+        Info::the()->init(optarg);
+        init_info = false;
+        break;
+
+      case 'C':
+        Config::the()->init(optarg);
+        init_config = false;
+        break;
     }
   }
 
+  Sysfex::import_config(init_config, init_info);
   Sysfex::run();
   return 0;
 }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,9 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "modules/cpu.hpp"
+#include <array>
 
 std::string cpu() {
-  std::string model_name = "model name";
+  constexpr std::string_view model_name = "model name";
   std::string output;
 
   std::ifstream cpu_info("/proc/cpuinfo");
@@ -47,13 +48,13 @@ std::string cpu() {
   output = output.substr(model_name.length());
 
   /*Remove unnecessary patterns from output */
-  std::vector<std::string> removables = {
+  constexpr std::array<std::string_view, 13> removables = {
     "(TM)", "(tm)", "(R)", "(r)", "CPU", "(Processor)", "Technologies, Inc",
     "Core", "Dual-Core", "Quad-Core", "Six-Core", "Eight-Core"
   };
 
-  for (auto removable : removables) {
-    size_t pos = output.find(removable);
+  for (const std::string_view removable : removables) {
+    const size_t pos = output.find(removable);
     if (pos != std::string::npos) {
       output.erase(pos, removable.length());
     }

--- a/src/modules/distro.cpp
+++ b/src/modules/distro.cpp
@@ -26,7 +26,7 @@ std::string distro() {
   }
 
   std::string output;
-  std::string pretty_name = "PRETTY_NAME=\"";
+  constexpr std::string_view pretty_name = "PRETTY_NAME=\"";
 
   while (std::getline(infile, output)) {
     if (output.find(pretty_name) != std::string::npos) {

--- a/src/modules/gpu.cpp
+++ b/src/modules/gpu.cpp
@@ -18,9 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "modules/gpu.hpp"
+#include <array>
 
 std::string gpu() {
-  std::vector<std::string> removables = {
+  constexpr std::array<std::string_view, 2> removables = {
     "Integrated Graphics Controller", "Corporation"
   };
 
@@ -51,7 +52,7 @@ std::string gpu() {
       }
 
       for (const auto& removable: removables) {
-        size_t pos = gpu.find(removable);
+        const size_t pos = gpu.find(removable);
         if (pos != std::string::npos) {
           gpu.erase(pos, removable.length());
         }

--- a/src/modules/model.cpp
+++ b/src/modules/model.cpp
@@ -38,6 +38,5 @@ std::string model() {
   getline(product_version, model_version);
   product_version.close();
 
-  std::string output = model_name + " " + model_version;
-  return output;
+  return model_name + " " + model_version;
 }

--- a/src/modules/pkgs.cpp
+++ b/src/modules/pkgs.cpp
@@ -21,55 +21,55 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "modules/pkgs.hpp"
 
 std::string pkgs() {
-  std::ostringstream output;
+  std::string output;
 
   /* Feel free to open a PR to include a package manager not listed here */
 
   /* dpkg (Debian/Ubuntu) */
   if (std::filesystem::exists("/bin/dpkg") or std::filesystem::exists("/usr/bin/dpkg")) {
-    output << sfUtils::get_output_of("dpkg --get-selections | wc -l") << " (dpkg) ";
+    output += sfUtils::get_output_of("dpkg --get-selections | wc -l") + " (dpkg) ";
   }
 
   /* flatpak */
   if (std::filesystem::exists("/bin/flatpak") or std::filesystem::exists("/usr/bin/flatpak")) {
-    output << sfUtils::get_output_of("flatpak list | wc -l") << " (flatpak) ";
+    output += sfUtils::get_output_of("flatpak list | wc -l") + " (flatpak) ";
   }
 
   /* nix (NixOS) */
   if (std::filesystem::exists("/nix")) {
     if (std::filesystem::exists("/etc/nix")) {
-      output << sfUtils::get_output_of("nix-store --query --requisites /run/current-system | wc -l");
+      output += sfUtils::get_output_of("nix-store --query --requisites /run/current-system | wc -l");
     } else {
-      output << sfUtils::get_output_of("nix-env -q | wc -l");
+      output += sfUtils::get_output_of("nix-env -q | wc -l");
     }
-    output << " (nix) ";
+    output += " (nix) ";
   }
 
   /* pacman (Arch/Manjaro) */
   if (std::filesystem::exists("/bin/pacman") or std::filesystem::exists("/usr/bin/pacman")) {
-    output << sfUtils::get_output_of("pacman -Qq | wc -l") + " (pacman) ";
+    output += sfUtils::get_output_of("pacman -Qq | wc -l") + " (pacman) ";
   }
 
   /* portage (Gentoo) */
   if (std::filesystem::exists("/bin/emerge") or std::filesystem::exists("/usr/bin/emerge")) {
-    output << sfUtils::get_output_of("echo -n $(cd /var/db/pkg && ls -d */* | wc -l") << " (emerge) ";
+    output += sfUtils::get_output_of("echo -n $(cd /var/db/pkg && ls -d */* | wc -l") + " (emerge) ";
   }
 
   /* rpm (OpenSUSE) */
   if (std::filesystem::exists("/var/lib/rpm")) {
-    output << sfUtils::get_output_of("rpm -qa | wc -l") << " (rpm) ";
+    output += sfUtils::get_output_of("rpm -qa | wc -l") + " (rpm) ";
   }
 
   /* Snap */
   if (std::filesystem::exists("/bin/snap") or std::filesystem::exists("/usr/bin/snap")) {
     int pkg_count = stoi(sfUtils::get_output_of("snap list | wc -l")) - 1; // Output includes a header row
-    output << std::to_string(pkg_count) << " (snap) ";
+    output += std::to_string(pkg_count) + " (snap) ";
   }
 
   /* XBPS (Void Linux) */
   if (std::filesystem::exists("/bin/xbps-install") or std::filesystem::exists("/usr/bin/xbps-install")) {
-    output << sfUtils::get_output_of("xbps-query -l | wc -l") << " (xbps) ";
+    output += sfUtils::get_output_of("xbps-query -l | wc -l") + " (xbps) ";
   }
 
-  return output.str();
+  return output;
 }

--- a/src/modules/resolution.cpp
+++ b/src/modules/resolution.cpp
@@ -24,7 +24,7 @@ std::string resolution() {
 
   for (const auto& entry : std::filesystem::directory_iterator("/sys/class/drm")) {
     if (entry.is_directory()) {
-      std::filesystem::path modes_path = entry.path() / "modes";
+      const std::filesystem::path& modes_path = entry.path() / "modes";
       if (std::filesystem::exists(modes_path)) {
         std::ifstream modes_file(modes_path);
         if (modes_file.is_open()) {

--- a/src/modules/uptime.cpp
+++ b/src/modules/uptime.cpp
@@ -34,23 +34,23 @@ std::string uptime() {
   int mins = static_cast<int>((uptime - days * 86400 - hours * 3600) / 60);
   int secs = static_cast<int>(uptime - days * 86400 - hours * 3600 - mins * 60);
 
-  std::ostringstream output;
+  std::string output;
 
   if (days) {
-    output << days << "day" << (days > 1 ? "s " : " ");
+    output += std::to_string(days) + "day" + (days > 1 ? "s " : " ");
   }
 
   if (hours) {
-    output << hours << "hour" << (hours > 1 ? "s " : " ");
+    output += std::to_string(hours) + "hour" + (hours > 1 ? "s " : " ");
   }
 
   if (mins) {
-    output << mins << "min" << (mins > 1 ? "s " : " ");
+    output += std::to_string(mins) + "min" + (mins > 1 ? "s " : " ");
   }
 
   if (secs) {
-    output << secs << "sec" << (secs > 1 ? "s" : "");
+    output += std::to_string(secs) + "sec" + (secs > 1 ? "s" : "");
   }
 
-  return output.str();
+  return output;
 }

--- a/src/sysfex.cpp
+++ b/src/sysfex.cpp
@@ -27,7 +27,7 @@ Report bugs: https://github.com/mehedirm6244/sysfex/issues\n\
   ", false);
 }
 
-void Sysfex::import_config() {
+void Sysfex::import_config(const bool init_config, const bool init_info) {
   const char* env = std::getenv("XDG_CONFIG_HOME");
   const std::filesystem::path& local_config = (env != nullptr) ?
     env : std::string("/home/") + std::getenv("USER") + "/.config";
@@ -47,18 +47,20 @@ void Sysfex::import_config() {
     Info::the()->generate_config_file(sysfex_local_info.string());
   }
   
-  Config::the()->init(sysfex_local_conf.string());
-  Info::the()->init(sysfex_local_info.string());
+  if (init_config)
+    Config::the()->init(sysfex_local_conf.string());
+  if (init_info)
+    Info::the()->init(sysfex_local_info.string());
 }
 
 void Sysfex::help() {
   std::cout << sfUtils::parse_string("\
 \\boldUsage:\\reset\n\
-  \\bold--about\\reset About Sysfex\n\
-  \\bold--help\\reset Show this page\n\
-  \\bold--ascii <path>\\reset Specify ASCII/image\n\
-  \\bold--config <path>\\reset Specify `config` file\n\
-  \\bold--info <path>\\reset Specify `info` file\n\
+  \\bold-b, --about\\reset About Sysfex\n\
+  \\bold-h, --help\\reset Show this page\n\
+  \\bold-a, --ascii <path>\\reset Specify ASCII/image\n\
+  \\bold-C, --config <path>\\reset Specify `config` file\n\
+  \\bold-i, --info <path>\\reset Specify `info` file\n\
   ", false);
 }
 

--- a/src/sysfex.cpp
+++ b/src/sysfex.cpp
@@ -28,26 +28,27 @@ Report bugs: https://github.com/mehedirm6244/sysfex/issues\n\
 }
 
 void Sysfex::import_config() {
-  const std::filesystem::path local_config = (std::getenv("XDG_CONFIG_HOME") != nullptr) ?
-    std::string(std::getenv("XDG_CONFIG_HOME")) : std::string("/home/") + std::getenv("USER") + "/.config";
-  const std::filesystem::path sysfex_conf_path = local_config / "sysfex";
-  const std::filesystem::path sysfex_local_conf = sysfex_conf_path / "config";
-  const std::filesystem::path sysfex_local_info = sysfex_conf_path / "info";
+  const char* env = std::getenv("XDG_CONFIG_HOME");
+  const std::filesystem::path& local_config = (env != nullptr) ?
+    env : std::string("/home/") + std::getenv("USER") + "/.config";
+  const std::filesystem::path& sysfex_conf_path = local_config / "sysfex";
+  const std::filesystem::path& sysfex_local_conf = sysfex_conf_path / "config";
+  const std::filesystem::path& sysfex_local_info = sysfex_conf_path / "info";
 
   if (!std::filesystem::exists(sysfex_conf_path)) {
     std::filesystem::create_directories(sysfex_conf_path);
   }
   
   if (!std::filesystem::exists(sysfex_local_conf)) {
-    Config::the()->generate_config_file(sysfex_local_conf);
+    Config::the()->generate_config_file(sysfex_local_conf.string());
   }
 
   if (!std::filesystem::exists(sysfex_local_info)) {
-    Info::the()->generate_config_file(sysfex_local_info);
+    Info::the()->generate_config_file(sysfex_local_info.string());
   }
   
-  Config::the()->init(sysfex_local_conf);
-  Info::the()->init(sysfex_local_info);
+  Config::the()->init(sysfex_local_conf.string());
+  Info::the()->init(sysfex_local_info.string());
 }
 
 void Sysfex::help() {
@@ -66,11 +67,11 @@ void Sysfex::run() {
   size_t line_count = 0;
 
   if (Config::the()->get_property("clear_screen") != "0") {
-    std::system("clear");
+    sfUtils::taur_exec({ "sh", "-c", "clear" });
   }
 
   /* Print ASCII if it exists */
-  std::filesystem::path ascii_path = Config::the()->get_property("ascii");
+  const std::filesystem::path& ascii_path = Config::the()->get_property("ascii");
   if (std::filesystem::exists(ascii_path)) {
     if (sfImage::is_supported_image(ascii_path)) {
       longest_line_width = std::stoi(Config::the()->get_property("image_width"));
@@ -82,7 +83,7 @@ void Sysfex::run() {
       std::string current_line;
 
       while (std::getline(ascii_file, current_line)) {
-        size_t current_line_width = sfUtils::get_string_display_width(current_line);
+        const size_t current_line_width = sfUtils::get_string_display_width(current_line);
         longest_line_width = std::max(longest_line_width, current_line_width);
         std::cout << sfUtils::parse_string(current_line, false) << '\n';
         line_count++;
@@ -115,7 +116,7 @@ void Sysfex::run() {
 
   if (line_count > Info::the()->get_info_size() and
       Config::the()->get_property("info_beside_ascii") == "1") {
-    size_t offset = line_count - Info::the()->get_info_size() - 1;
+    const size_t offset = line_count - Info::the()->get_info_size() - 1;
     std::cout << "\033[" << offset << "B";
   }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -105,9 +105,8 @@ std::string sfUtils::parse_string(const std::string_view source, bool peel) {
 
 /**
  * remove all white spaces (' ', '\t', '\n') from start and end of input
- * inplace!
  * @param input
- * @Original https://github.com/lfreist/hwinfo/blob/main/include/hwinfo/utils/stringutils.h#L50
+ * @Original https://github.com/Toni500github/customfetch/blob/main/src/util.cpp#L177
  */
 std::string sfUtils::trim_string_spaces(std::string input) {
     if (input.empty())
@@ -144,11 +143,10 @@ std::string sfUtils::trim_string_spaces(std::string input) {
 
 /** Executes commands with execvp() and keep the program running without existing
  * @param cmd_str The command to execute
- * @param exitOnFailure Whether to call exit(1) on command failure.
  * @return true if the command successed, else false
  * @Original https://github.com/BurntRanch/TabAUR/blob/main/src/util.cpp#L484
  */
-bool sfUtils::taur_exec(const std::vector<std::string> cmd_str)
+bool sfUtils::taur_exec(const std::vector<std::string_view> cmd_str)
 {
     std::vector<const char*> cmd;
     for (const std::string_view str : cmd_str)
@@ -163,10 +161,10 @@ bool sfUtils::taur_exec(const std::vector<std::string> cmd_str)
     else if (pid == 0)
     {
         cmd.push_back(nullptr);
-        execvp(cmd[0], const_cast<char* const*>(cmd.data()));
+        execvp(cmd.at(0), const_cast<char* const*>(cmd.data()));
 
         // execvp() returns instead of exiting when failed
-        std::cerr << "An error has occurred: " << cmd[0] << ':' << strerror(errno);
+        std::cerr << "An error has occurred: " << cmd.at(0) << ':' << strerror(errno);
     }
     else if (pid > 0)
     {  // we wait for the command to finish then start executing the rest


### PR DESCRIPTION
This PR is only for improving the code and some perfomances, because I was kinda bored :p (and because it has good practise). Didn't change the codestyle.

## What I improved in code
* Use `std::string_view` instead of `const std::string&` in function parameters https://www.learncpp.com/cpp-tutorial/pass-by-const-lvalue-reference/#stringparameter
* Stop using `std::pair` https://www.reddit.com/r/cpp/comments/ar4ghs/stdpair_disappointing_performance/
* Start using `const std::string&` when it's possible instead of normal `std::string`
* Adding new function `taur_exec()` for executing commands instead of `std::system()`
* Add more `const` (good practise)
* Start using more often references, especially in `std::filesystem::path`
* Start using `getopt_long()` for arguments, and so add short arguments
* Use more often `constexpr std::array<std::string_view. N>` instead of `std::vector<std::string>` for already defined arrays

## What I improved in perfomance
* Improve runtime when running with `--help` or `--about`. This happened because sysfex inits the config and info before even checking if running with those arguments.
  Normal:
  ![image](https://github.com/user-attachments/assets/b77a68df-6fce-487f-9391-e2b5395f99e4)

  With my patch:
  ![image](https://github.com/user-attachments/assets/86425dc2-d501-4199-9238-2b558f9c242d)
